### PR TITLE
Stubbed out matching default boxes with annotations

### DIFF
--- a/net/plot.py
+++ b/net/plot.py
@@ -8,6 +8,8 @@ import PIL.Image
 import PIL.ImageFont
 import cv2
 
+import net.utilities
+
 
 def draw_annotation_label(pil_image, annotation, color, font):
     """
@@ -69,3 +71,18 @@ def get_annotated_image(image, annotations, colors, draw_labels=True, font_path=
         draw_annotation_label(pil_image, annotation, color, font)
 
     return np.array(pil_image)
+
+
+def get_image_with_boxes(image, boxes, color):
+    """
+    Creates a new image with boxes drawn on original image in color specified
+    :param image: numpy array
+    :param boxes: list of boxes in corner format
+    :param color: 3-element tuple
+    :return: numpy array
+    """
+
+    boxes_annotations = net.utilities.get_annotations_from_default_boxes(boxes)
+    colors = [color for _ in boxes]
+
+    return net.plot.get_annotated_image(image, boxes_annotations, colors=colors, draw_labels=False)

--- a/scripts/models_theoretical_bounds_analysis.py
+++ b/scripts/models_theoretical_bounds_analysis.py
@@ -10,6 +10,39 @@ import tqdm
 
 import net.data
 import net.ssd
+import net.utilities
+
+
+def analyse_theoretical_precision(config):
+    """
+    Analyse theoretical precision of SSD model on VOC dataset
+    """
+
+    voc_samples_generator_factory = net.data.VOCSamplesGeneratorFactory(
+        config["voc"]["data_directory"], config["voc"]["validation_set_path"], config["size_factor"])
+
+    ssd_input_generator_factory = net.data.SSDInputGeneratorFactory(
+        voc_samples_generator_factory, config["objects_filtering"])
+
+    ssd_input_generator = ssd_input_generator_factory.get_generator()
+
+    matching_analysis_generator = net.ssd.get_matching_analysis_generator(
+        config["vggish_model_configuration"], ssd_input_generator)
+
+    matched_annotations = []
+    unmatched_annotations = []
+
+    for _ in tqdm.tqdm(range(10)):
+
+        single_image_matched_annotations, single_image_unmatched_annotations = next(matching_analysis_generator)
+
+        matched_annotations.extend(single_image_matched_annotations)
+        unmatched_annotations.extend(single_image_unmatched_annotations)
+
+    ssd_input_generator_factory.stop_generator()
+
+    print(len(matched_annotations))
+    print(len(unmatched_annotations))
 
 
 def main():
@@ -25,26 +58,7 @@ def main():
     with open(arguments.config) as file:
         config = yaml.safe_load(file)
 
-    voc_samples_generator_factory = net.data.VOCSamplesGeneratorFactory(
-        config["voc"]["data_directory"], config["voc"]["validation_set_path"], config["size_factor"])
-
-    ssd_input_generator_factory = net.data.SSDInputGeneratorFactory(
-        voc_samples_generator_factory, config["objects_filtering"])
-
-    ssd_input_generator = ssd_input_generator_factory.get_generator()
-
-    default_boxes_factory = net.ssd.DefaultBoxesFactory(config["vggish_model_configuration"])
-
-    for _ in tqdm.tqdm(range(10)):
-
-        image, annotations = next(ssd_input_generator)
-        default_boxes_matrix = default_boxes_factory.get_default_boxes_matrix(image.shape)
-
-        print(image.shape)
-        print(len(annotations))
-        print(default_boxes_matrix)
-
-    ssd_input_generator_factory.stop_generator()
+    analyse_theoretical_precision(config)
 
 
 if __name__ == "__main__":

--- a/tests/commit_stage/unit_tests/test_utilities.py
+++ b/tests/commit_stage/unit_tests/test_utilities.py
@@ -271,3 +271,47 @@ def test_get_annotations_from_default_boxes():
     actual = net.utilities.get_annotations_from_default_boxes(default_boxes_matrix)
 
     assert expected == actual
+
+
+def test_get_matched_boxes_indices_decision_can_be_made_looking_at_borders():
+    """
+    Test code matching matrix of bounding boxes with a template box.
+    Only simple input is used - boxes either hardly overlap, or overlap with high IOU.
+    """
+
+    template_box = (100, 100, 200, 200)
+
+    boxes_matrix = np.array([
+        [50, 50, 140, 140],
+        [101, 101, 200, 200],
+        [170, 170, 200, 200],
+        [99, 99, 201, 201],
+
+    ])
+
+    expected = np.array([1, 3])
+    actual = net.utilities.get_matched_boxes_indices(template_box, boxes_matrix)
+
+    assert np.all(expected == actual)
+
+
+def test_get_matched_boxes_indices_decision_can_be_made_looking_boxes_sizes_default_boxes_inside_template_box():
+    """
+    Test code matching matrix of bounding boxes with a template box.
+    All default boxes are inside template box, but some have too small area to have high IOU
+    """
+
+    template_box = (100, 100, 200, 200)
+
+    boxes_matrix = np.array([
+        [101, 101, 199, 199],
+        [140, 140, 160, 160],
+        [102, 102, 198, 198],
+        [145, 145, 155, 155],
+
+    ])
+
+    expected = np.array([0, 2])
+    actual = net.utilities.get_matched_boxes_indices(template_box, boxes_matrix)
+
+    assert np.all(expected == actual)


### PR DESCRIPTION
Matching is not perfect yet - it only does simple, rough matching based on boxes coordinates and sizes, but doesn't actually compute IOU with annotation boxes yet.